### PR TITLE
Use only the first type in a union type

### DIFF
--- a/dataspecs/typing.py
+++ b/dataspecs/typing.py
@@ -56,9 +56,14 @@ def get_dataclasses(obj: Any, /) -> tuple[DataClass, ...]:
     return tuple(filter(is_dataclass, get_annotations(obj)))
 
 
+def get_first(obj: Any, /) -> Any:
+    """Return the first type if a type hint is a union type."""
+    return get_args(obj)[0] if is_union(obj) else obj
+
+
 def get_subscriptions(obj: Any, /) -> tuple[Any, ...]:
     """Return subscriptions of a type hint if they exist."""
-    return get_args(get_annotated(obj))
+    return get_args(get_first(get_annotated(obj)))
 
 
 def get_tags(obj: Any, /) -> tuple[TagBase, ...]:
@@ -79,3 +84,8 @@ def is_strpath(obj: Any, /) -> TypeGuard[StrPath]:
 def is_tag(obj: Any, /) -> TypeGuard[TagBase]:
     """Check if an object is a specification tag."""
     return isinstance(obj, TagBase)
+
+
+def is_union(obj: Any, /) -> bool:
+    """Check if a type hint is a union type."""
+    return get_origin(Union[obj]) is Union  # type: ignore

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import Annotated as Ann, Any
+from typing import Annotated as Ann, Any, Union
 
 
 # dependencies
@@ -11,11 +11,13 @@ from dataspecs.typing import (
     get_annotated,
     get_annotations,
     get_dataclasses,
+    get_first,
     get_subscriptions,
     get_tags,
     is_annotated,
     is_strpath,
     is_tag,
+    is_union,
 )
 from pytest import mark
 
@@ -59,12 +61,25 @@ data_get_dataclasses: TestData = [
     (int, ()),
 ]
 
+data_get_first: TestData = [
+    (Ann[Union[int, None], "ann"], Ann[Union[int, None], "ann"]),
+    (Union[int, None], int),
+    (Ann[int, "ann"], Ann[int, "ann"]),
+    (int, int),
+]
+
 data_get_subscriptions: TestData = [
+    (Ann[Union[dict[str, int], None], "ann"], (str, int)),
     (Ann[dict[str, int], "ann"], (str, int)),
+    (Union[dict[str, int], None], (str, int)),
     (dict[str, int], (str, int)),
+    (Ann[Union[list[int], None], "ann"], (int,)),
     (Ann[list[int], "ann"], (int,)),
+    (Union[list[int], None], (int,)),
     (list[int], (int,)),
+    (Ann[Union[int, None], "ann"], ()),
     (Ann[int, "ann"], ()),
+    (Union[int, None], ()),
     (int, ()),
 ]
 
@@ -93,6 +108,12 @@ data_is_tag: TestData = [
     (1, False),
 ]
 
+data_is_union: TestData = [
+    (Ann[Union[int, None], "ann"], False),
+    (Union[int, None], True),
+    (int, False),
+]
+
 
 # test functions
 @mark.parametrize("tester, expected", data_get_annotated)
@@ -108,6 +129,11 @@ def test_get_annotations(tester: Any, expected: Any) -> None:
 @mark.parametrize("tester, expected", data_get_dataclasses)
 def test_get_dataclasses(tester: Any, expected: Any) -> None:
     assert get_dataclasses(tester) == expected
+
+
+@mark.parametrize("tester, expected", data_get_first)
+def test_get_first(tester: Any, expected: Any) -> None:
+    assert get_first(tester) == expected
 
 
 @mark.parametrize("tester, expected", data_get_subscriptions)
@@ -133,3 +159,8 @@ def test_is_strpath(tester: Any, expected: bool) -> None:
 @mark.parametrize("tester, expected", data_is_tag)
 def test_is_tag(tester: Any, expected: bool) -> None:
     assert is_tag(tester) == expected
+
+
+@mark.parametrize("tester, expected", data_is_union)
+def test_is_union(tester: Any, expected: Any) -> None:
+    assert is_union(tester) == expected


### PR DESCRIPTION
Closes #16.